### PR TITLE
Fix logic around 'Previous run' warning

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -138,12 +138,12 @@ function run_export(&$export) {
 	$exported = 0;
 
 	if (!empty($export['export_pid'])) {
+		cacti_log('WARNING: Previous run of the following Graph Export ended in an unclean state Export:' . $export['name']);
+
 		if (posix_kill($export['export_pid'], 0) !== false) {
 			cacti_log('WARNING: Can not start the following Graph Export:' . $export['name'] . ' is still running');
 			return;
 		}
-	}else{
-		cacti_log('WARNING: Previous run of the following Graph Export ended in an unclean state Export:' . $export['name']);
 	}
 
 	db_execute_prepared('UPDATE graph_exports 


### PR DESCRIPTION
The 'Previous run' warning is printed incorrectly when the previous run was
successful. Move the warning into the correct 'if' branch.

Thanks for the plugin. I noticed in the logs that we always see the 'Previous run' warnings after successful exports.