### PR TITLE
Fix variable name mismatch from INFO file.

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -92,7 +92,7 @@ function gexport_check_upgrade() {
 			version='" . $version['version']  . "', 
 			name='"    . $version['longname'] . "', 
 			author='"  . $version['author']   . "', 
-			webpage='" . $version['url']      . "' 
+			webpage='" . $version['homepage'] . "' 
 			WHERE directory='" . $version['name'] . "' ");
 
 		db_execute("ALTER TABLE graph_exports MODIFY column export_user VARCHAR(40) DEFAULT ''");


### PR DESCRIPTION
After upgrading to 1.2, we saw the following error:

2017/06/30 14:40:40 - ERROR PHP NOTICE in  Plugin 'gexport': Undefined index: url in file: /usr/share/cacti/plugins/gexport/setup.php  on line: 95
2017/06/30 14:40:40 - CMDPHP PHP ERROR NOTICE Backtrace: (/plugins.php: 25 include)(/include/auth.php: 27 include)(/include/global.php: 322 include_once)(/include/global_arrays.php: 1538 api_plugin_hook)(/lib/plugins.php: 69 api_plugin_run_plugin_hook)(/lib/plugins.php: 162 gexport_config_arrays)(/plugins/gexport/setup.php: 161 gexport_check_upgrade)(/plugins/gexport/setup.php: 95 CactiErrorHandler)(/lib/functions.php: 4368 cacti_debug_backtrace)

Small fix needed, to either change the INFO file or the variable name in gexport_check_upgrade().

The INFO file has 'homepage = ..', but the gexport_check_upgrade() function
thinks it's called 'url = ..'.