### PR TITLE
Remove fixed tmp dir setting

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -172,12 +172,10 @@ function gexport_config_arrays() {
 	asort($themes);
 	$dir->close();
 
-	if ($config['cacti_server_os'] == 'unix') {
-		$tmp = '/tmp/';
-	}else{
-		$tmp = getenv('TEMP');
-	}
-
+	
+	// Replace OS check and fixed temp dir with sys_get_temp_dir()
+	$tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR;
+	
 	if (isset($_SESSION['gexport_message']) && $_SESSION['gexport_message'] != '') {
 		$messages['gexport_message'] = array('message' => $_SESSION['gexport_message'], 'type' => 'info');
 	}


### PR DESCRIPTION
With everyone using PHP >5.2 we could use sys_get_temp_dir() to get the temporarty directory. Alternative is to have this as a setting default to the value of the sys_get_temp_dir() function ?