### PR TITLE
Fix incorrect export time range

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1007,7 +1007,11 @@ function export_graph_files($export, $user, $export_path, $local_graph_id)
 				$graph_data_array['export_filename'] = $export_path . '/graphs/graph_' . $local_graph_id . '_' . $rra['id'] . '.png';
 				$graph_data_array['export']          = true;
 				$graph_data_array['graph_end']       = time() - read_config_option('poller_interval');
-				$graph_data_array['graph_start']     = time() - ($rra['rows'] * $rra['step'] * $rra['steps']);
+				if (!empty($rra['timespan'])) {
+					$graph_data_array['graph_start']  = $graph_data_array['graph_end'] - $rra['timespan'];
+				} else {				
+					$graph_data_array['graph_start']     = $graph_data_array['graph_end'] - ($rra['rows'] * $rra['step'] * $rra['steps']);
+				}
 
 				check_remove($graph_data_array['export_filename']);
 


### PR DESCRIPTION
Current graphs are exported will all of the steps of an RRA and ignores the graph timespan.
This creates graphs that look different in the export than they look in the cacti web interface.
For example if you have a Monthly RRA that has 2 months of retention but a 1 month timespan the web UI will show 1 month of data but the exported graph will show 2 months of data.

This patch uses the same logic as graph.php to use the RRA timespan to export graphs with the correct date range.