### PR TITLE
Changes from forum discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Got any ideas or complaints, please create an issue in GitHub.
 
 * issue#37: Empty site variable may cause errors to appear
 * issue#38: Searching for graph exports does not work with some international characters
+* issue#42: Setting export max graphs to 0 does not include all, as documentation suggests
 
 --- 1.4.2 ---
 

--- a/functions.php
+++ b/functions.php
@@ -690,6 +690,8 @@ function export_graphs(&$export, $export_path) {
 		$user = -1;
 	}
 
+    export_debug('Export presentation is ' . $export['export_presentation']);
+
 	if ($export['export_presentation'] == 'tree') {
 		if ($trees != '0') {
 			$sql_where = 'gt.id IN(' . $trees . ')';
@@ -697,7 +699,7 @@ function export_graphs(&$export, $export_path) {
 
 		$trees = get_allowed_trees(false, false, $sql_where, 'name', '', $total_rows, $user);
 
-		export_debug('There are ' . sizeof($trees) . ' to export');
+		export_debug('There are ' . sizeof($trees) . ' trees to export');
 
 		if (sizeof($trees)) {
 			foreach($trees as $tree) {
@@ -714,7 +716,7 @@ function export_graphs(&$export, $export_path) {
 				'local_graph_id', 'local_graph_id'
 			);
 
-			export_debug('There are ' . sizeof($graphs) . ' to export for all trees.');
+			export_debug('There are ' . sizeof($graphs) . ' graphs to export for all trees');
 
 			if (sizeof($graphs)) {
 				foreach($graphs as $local_graph_id) {

--- a/functions.php
+++ b/functions.php
@@ -704,19 +704,18 @@ function export_graphs(&$export, $export_path) {
 		if (sizeof($trees)) {
 			foreach($trees as $tree) {
 				$ntree[] = $tree['id'];
+                export_debug('Tree \'' . $tree['name'] . '\' with id \'' . $tree['id'] . '\' is allowed');
 			}
 		}
 
 		if (sizeof($ntree)) {
 			$graphs = array_rekey(
-				db_fetch_assoc('SELECT DISTINCT local_graph_id
+                db_fetch_assoc('SELECT DISTINCT local_graph_id
 					FROM graph_tree_items
 					WHERE local_graph_id > 0
 					AND graph_tree_id IN(' . implode(', ', $ntree) . ')'),
-				'local_graph_id', 'local_graph_id'
-			);
-
-			export_debug('There are ' . sizeof($graphs) . ' graphs to export for all trees');
+                'local_graph_id','local_graph_id'
+            );
 
 			if (sizeof($graphs)) {
 				foreach($graphs as $local_graph_id) {
@@ -726,10 +725,14 @@ function export_graphs(&$export, $export_path) {
 				}
 			}
 
+            export_debug('There are ' . sizeof($graphs) . ' graphs not in hosts to export for all trees');
+
 			$hosts = db_fetch_cell_prepared('SELECT GROUP_CONCAT(DISTINCT host_id)
 				FROM graph_tree_items
 				WHERE graph_tree_id IN(?)',
 				array(implode(', ', $ntree)));
+
+            export_debug('There are ' . sizeof(explode(',',$hosts)) . ' hosts to export for all trees');
 
 			if ($hosts != '') {
 				$sql_where = 'gl.host_id IN(' . $hosts . ')';
@@ -743,6 +746,8 @@ function export_graphs(&$export, $export_path) {
 					}
 				}
 			}
+
+			export_debug('There are ' . sizeof($ngraph) . ' total graphs to export for all trees');
 		}
 	}else{
 		if ($sites != '') {

--- a/functions.php
+++ b/functions.php
@@ -725,14 +725,14 @@ function export_graphs(&$export, $export_path) {
 				}
 			}
 
-            export_debug('There are ' . sizeof($graphs) . ' graphs not in hosts to export for all trees');
+			export_debug('There are ' . sizeof($graphs) . ' graphs not in hosts to export for all trees');
 
 			$hosts = db_fetch_cell_prepared('SELECT GROUP_CONCAT(DISTINCT host_id)
 				FROM graph_tree_items
 				WHERE graph_tree_id IN(?)',
 				array(implode(', ', $ntree)));
 
-            export_debug('There are ' . sizeof(explode(',',$hosts)) . ' hosts to export for all trees');
+			export_debug('There are ' . sizeof(explode(',',$hosts)) . ' hosts to export for all trees');
 
 			if ($hosts != '') {
 				$sql_where = 'gl.host_id IN(' . $hosts . ')';
@@ -783,7 +783,7 @@ function export_graphs(&$export, $export_path) {
 
 			$exported++;
 
-			if ($exported >= $export['graph_max'] && $export['graph_max'] > 0) {
+			if ($export['graph_max'] && $exported >= $export['graph_max']) {
 				db_execute_prepared('UPDATE graph_exports
 					SET last_error="WARNING: Max number of Graphs ' . $export['graph_max'] . ' reached",
 					last_errored=NOW()

--- a/functions.php
+++ b/functions.php
@@ -710,7 +710,7 @@ function export_graphs(&$export, $export_path) {
 
 		if (sizeof($ntree)) {
 			$graphs = array_rekey(
-                db_fetch_assoc('SELECT DISTINCT local_graph_id
+				db_fetch_assoc('SELECT DISTINCT local_graph_id
 					FROM graph_tree_items
 					WHERE local_graph_id > 0
 					AND graph_tree_id IN(' . implode(', ', $ntree) . ')'),

--- a/functions.php
+++ b/functions.php
@@ -776,7 +776,7 @@ function export_graphs(&$export, $export_path) {
 
 			$exported++;
 
-			if ($exported >= $export['graph_max']) {
+			if ($exported >= $export['graph_max'] && $export['graph_max'] > 0) {
 				db_execute_prepared('UPDATE graph_exports
 					SET last_error="WARNING: Max number of Graphs ' . $export['graph_max'] . ' reached",
 					last_errored=NOW()


### PR DESCRIPTION
The first commit fixes the issue when setting max_graphs to 0 (for unlimited) as the function was not checking for that before dumping with error.

The latter commits make the debug logging a bit more concise to figure out what is going on with the export process.  

I was able to get the tree view to reproduce the 0.8.8g behavior of creating a directory per tree branch, but this entailed a much more extensive rewrite.  Since this wasn't necessary for the mainline branch, I did not add that mess to the PR.