### PR TITLE
refactor: DRY gexport page layout wrapper

### DIFF
--- a/gexport.php
+++ b/gexport.php
@@ -25,6 +25,7 @@
 chdir('../../');
 include('./include/auth.php');
 include_once('./plugins/gexport/functions.php');
+include_once('./plugins/gexport/ui_helpers.php');
 
 $export_actions = array(
 	'1' => __('Delete', 'gexport'),
@@ -51,19 +52,11 @@ switch (get_request_var('action')) {
 
 		break;
 	case 'edit':
-		top_header();
-
-		export_edit();
-
-		bottom_footer();
+		gexport_render_with_layout('export_edit');
 
 		break;
 	default:
-		top_header();
-
-		gexport();
-
-		bottom_footer();
+		gexport_render_with_layout('gexport');
 
 		break;
 }
@@ -937,4 +930,3 @@ function gexport() {
 
 	form_end();
 }
-

--- a/tests/test_layout_wrapper.php
+++ b/tests/test_layout_wrapper.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for shared layout wrapper routing in gexport.php      |
+ |                                                                         |
+ | Run: php tests/test_layout_wrapper.php                                  |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+$events = array();
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+function top_header() {
+	global $events;
+	$events[] = 'top_header';
+}
+
+function bottom_footer() {
+	global $events;
+	$events[] = 'bottom_footer';
+}
+
+require_once __DIR__ . '/../ui_helpers.php';
+
+$events = array();
+$runs = 0;
+
+gexport_render_with_layout(function () use (&$events, &$runs) {
+	$runs++;
+	$events[] = 'content';
+});
+
+assert_true('layout callback executes once', $runs === 1);
+assert_true('layout call order is top->content->bottom', $events === array('top_header', 'content', 'bottom_footer'));
+
+$source = file_get_contents(__DIR__ . '/../gexport.php');
+
+assert_true(
+	'edit action uses shared layout helper',
+	strpos($source, "gexport_render_with_layout('export_edit');") !== false
+);
+assert_true(
+	'default action uses shared layout helper',
+	strpos($source, "gexport_render_with_layout('gexport');") !== false
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);

--- a/ui_helpers.php
+++ b/ui_helpers.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('gexport_render_with_layout')) {
+	function gexport_render_with_layout($renderer) {
+		top_header();
+		call_user_func($renderer);
+		bottom_footer();
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared `gexport_render_with_layout()` helper for page wrapper rendering
- route `edit` and default action paths in `gexport.php` through the helper
- preserve behavior while removing duplicated `top_header()/bottom_footer()` wrapper logic

## Tests
- `php -l gexport.php`
- `php -l ui_helpers.php`
- `php -l tests/test_layout_wrapper.php`
- `php tests/test_layout_wrapper.php`

Closes #64
