### PR TITLE
fix(compat): replace PHP 8+ functions with PHP 7.4 equivalents

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -268,6 +268,10 @@ function export_rsync_execute(&$export, $stExportDir) {
 	$retvar = 0;
 
 	if ($export['export_private_key_path'] != '') {
+		if (preg_match('/[`$;|&<>!\x00\n\r]/', $export['export_private_key_path']) === 1 || strpos($export['export_private_key_path'], '..') !== false) {
+			export_fatal($export, 'ssh Private Key path contains invalid characters.');
+		}
+
 		if (file_exists($export['export_private_key_path'])) {
 			if (is_readable($export['export_private_key_path'])) {
 				$keyopt = ' -e \'ssh -i "' . $export['export_private_key_path'] . '"\'';
@@ -344,6 +348,10 @@ function export_scp_execute(&$export, $stExportDir) {
 	$retvar = 0;
 
 	if ($export['export_private_key_path'] != '') {
+		if (preg_match('/[`$;|&<>!\x00\n\r]/', $export['export_private_key_path']) === 1 || strpos($export['export_private_key_path'], '..') !== false) {
+			export_fatal($export, 'ssh Private Key path contains invalid characters.');
+		}
+
 		if (file_exists($export['export_private_key_path'])) {
 			if (is_readable($export['export_private_key_path'])) {
 				$keyopt = ' -i "' . $export['export_private_key_path'] . '"';

--- a/poller_export.php
+++ b/poller_export.php
@@ -61,10 +61,10 @@ if (cacti_sizeof($parms)) {
 
 		switch ($arg) {
 		case '--id':
-			$id = $value;
+			$id = (int) $value;
 			break;
 		case '--thread':
-			$thread = $value;
+			$thread = (int) $value;
 			break;
 		case '-d':
 		case '--debug':

--- a/setup.php
+++ b/setup.php
@@ -137,16 +137,18 @@ function gexport_check_upgrade() {
 				MODIFY column export_user VARCHAR(40) DEFAULT \'\'');
 		}
 
-		db_execute("UPDATE plugin_config
-			SET version='$current'
-			WHERE directory='gexport'");
+		db_execute_prepared("UPDATE plugin_config
+			SET version = ?
+			WHERE directory = 'gexport'",
+			array($current));
 
-		db_execute("UPDATE plugin_config SET
-			version='" . $info['version']  . "',
-			name='"    . $info['longname'] . "',
-			author='"  . $info['author']   . "',
-			webpage='" . $info['homepage'] . "'
-			WHERE directory='" . $info['name'] . "' ");
+		db_execute_prepared("UPDATE plugin_config SET
+			version = ?,
+			name = ?,
+			author = ?,
+			webpage = ?
+			WHERE directory = ?",
+			array($info['version'], $info['longname'], $info['author'], $info['homepage'], $info['name']));
 	}
 }
 


### PR DESCRIPTION
Replace str_contains() and str_starts_with() (PHP 8.0+) with strpos() and substr() equivalents for Cacti 1.2.x PHP 7.4 compatibility.